### PR TITLE
Update Cargo.toml fix name of repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 license = "MIT"
 author = "jakkunight"
 homepage = "https://jakkunight.github.io/ali/"
-repo = "https://github.com/jakkunight/ali"
+repository = "https://github.com/jakkunight/ali"
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.